### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,97 @@ examples/XMonad_changing_focus_duplicates_windows/XMonad/*.hi
 examples/XMonad_changing_focus_duplicates_windows/XMonad/*.o
 *.swp
 tmp/
+
+.Hoed
+
+# Created by https://www.gitignore.io/api/emacs,haskell
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+projectile-bookmarks.eld
+
+# directory configuration
+.dir-locals.el
+
+# saveplace
+places
+
+# url cache
+url/cache/
+
+# cedet
+ede-projects.el
+
+# smex
+smex-items
+
+# company-statistics
+company-statistics-cache.el
+
+# anaconda-mode
+anaconda-mode/
+
+### Haskell ###
+dist
+dist-*
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+*.eventlog
+.stack-work/
+cabal.project.local
+.HTF/
+
+# End of https://www.gitignore.io/api/emacs,haskell

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -294,6 +294,11 @@ runO' verbose program = do
       ct   = mkCompTree eqs ds
 
   writeFile ".Hoed/Events"     (unlines . map show . reverse $ events)
+#if defined(DEBUG)
+  writeFile ".Hoed/Cdss"       (unlines . map show $ cdss2)
+  writeFile ".Hoed/Eqs"        (unlines . map show $ eqs)
+  writeFile ".Hoed/compTree"   (unlines . map show $ eqs)
+#endif
 #if defined(TRANSCRIPT)
   writeFile ".Hoed/Transcript" (getTranscript events ti)
 #endif

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ImplicitParams  #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
@@ -370,3 +371,10 @@ logOwp handler filePath properties program = do
         showArc _          = ""
         showCompStmt s     = (show . vertexJmt) s ++ ": " ++ (show . vertexStmt) s
 
+
+#if __GLASGOW_HASKELL__ >= 710
+-- A catch-all instance for non observable types
+instance {-# OVERLAPPABLE #-} Observable a where
+  observer = observeOpaque "<?>"
+  constrain _ _ = error "constrained by untraced value"
+#endif

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -170,8 +170,9 @@ import           Debug.Hoed.Render
 import           Debug.Hoed.Serialize
 
 import           Data.IORef
-import           Prelude                hiding (Right)
-import           System.Directory       (createDirectoryIfMissing)
+import           Prelude                      hiding (Right)
+import           System.Console.Terminal.Size
+import           System.Directory             (createDirectoryIfMissing)
 import           System.IO
 import           System.IO.Unsafe
 
@@ -226,7 +227,10 @@ debugO program =
 -- @
 
 runO :: IO a -> IO ()
-runO = runOwith defaultHoedOptions{verbose=Verbose}
+runO program = do
+  window <- size
+  let w = maybe (prettyWidth defaultHoedOptions) width window
+  runOwith defaultHoedOptions{prettyWidth=w, verbose=Verbose} program
 
 runOwith :: HoedOptions -> IO a -> IO ()
 runOwith options program = do

--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -215,7 +215,11 @@ getLocation e s = getLocation' p
 
   where p = parentPosition . eventParent $ e
         j = parentUID . eventParent $ e
-        (Just getLocation') = IntMap.lookup j (locations s)
+        getLocation' =
+          case IntMap.lookup j (locations s) of
+            Just f -> f
+            Nothing -> error $ "Could not find location for j = " ++ show j ++
+                               "\nKnown locations are: " ++ show (IntMap.keys (locations s))
 
 setLocation :: Event -> (ParentPosition -> Bool) -> TraceInfo -> TraceInfo
 setLocation e getLoc s = s{locations=IntMap.insert i getLoc (locations s)}

--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -41,7 +41,7 @@ import           Debug.Hoed.Render
 import           Data.Graph.Libgraph
 import           Data.IntMap.Strict     (IntMap)
 import qualified Data.IntMap.Strict     as IntMap
-import           Data.List              (nub)
+import           Data.List              (group, sort)
 import           GHC.Generics
 import           Prelude                hiding (Right)
 
@@ -127,7 +127,9 @@ mkCompTree :: [CompStmt] -> [(UID,UID)] -> CompTree
 mkCompTree cs ds = Graph RootVertex vs as
 
   where vs = RootVertex : map (`Vertex` Unassessed) cs
-        as = map (\(i,j) -> Arc (findVertex i) (findVertex j) ()) (nub ds)
+        as = map (\(i,j) -> Arc (findVertex i) (findVertex j) ()) (snub ds)
+
+        snub = map head . group . sort
 
         -- A mapping from stmtUID to Vertex of all CompStmts in cs
         vMap :: IntMap Vertex

--- a/Debug/Hoed/Compat.hs
+++ b/Debug/Hoed/Compat.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE CPP           #-}
-module Debug.Hoed.Compat (sortOn, (<$), (<$>)) where
+{-# LANGUAGE CPP #-}
+module Debug.Hoed.Compat (addConstraint, sortOn, (<$), (<$>)) where
 
-import Control.Applicative
-import Data.List
+import           Control.Applicative
+import           Data.List
+import           Language.Haskell.TH
 
 #if __GLASGOW_HASKELL__ < 710
 sortOn :: Ord b => (a -> b) -> [a] -> [a]
@@ -10,4 +11,12 @@ sortOn f  = map snd . sortOn' fst .  map (\x -> (f x, x))
 
 sortOn' :: Ord b => (a -> b) -> [a] -> [a]
 sortOn' f = sortBy (\x y -> compare (f x) (f y))
+#endif
+
+addConstraint :: Name -> [Type] -> Pred
+addConstraint name args =
+#if __GLASGOW_HASKELL__ < 710
+      ClassP name args
+#else
+      foldl' AppT (ConT name) args
 #endif

--- a/Debug/Hoed/Compat.hs
+++ b/Debug/Hoed/Compat.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE CPP           #-}
+module Debug.Hoed.Compat (sortOn, (<$), (<$>)) where
+
+import Control.Applicative
+import Data.List
+
+#if __GLASGOW_HASKELL__ < 710
+sortOn :: Ord b => (a -> b) -> [a] -> [a]
+sortOn f  = map snd . sortOn' fst .  map (\x -> (f x, x))
+
+sortOn' :: Ord b => (a -> b) -> [a] -> [a]
+sortOn' f = sortBy (\x y -> compare (f x) (f y))
+#endif

--- a/Debug/Hoed/Console.hs
+++ b/Debug/Hoed/Console.hs
@@ -219,7 +219,12 @@ judgeCommand judgement =
     verbatim | Right <- judgement = "right"
              | Wrong <- judgement = "wrong"
 
-adbFrame st@State{..} = do
+adbFrame st@State{..} =
+  case cv of
+    RootVertex -> do
+      putStrLn "Out of vertexes"
+      return $ Up Nothing
+    _ -> do
       adb_stats compTree
       print $ vertexStmt cv
       case lookupPropositions ps cv of

--- a/Debug/Hoed/Console.hs
+++ b/Debug/Hoed/Console.hs
@@ -48,7 +48,7 @@ mainLoop cv trace compTree ps = do
   case words i of
     ["adb"]             -> adb cv trace compTree ps
     ["observe", regexp] -> do printStmts compTree regexp; loop
-    ["observe"]         -> do printStmts compTree ""; loop
+    ["observe"]         -> do printStmts compTree ".*"; loop
     ["exit"]            -> return ()
     _                   -> do help; loop
   where

--- a/Debug/Hoed/Console.hs
+++ b/Debug/Hoed/Console.hs
@@ -227,8 +227,14 @@ printStmts' gs = do
       "--- stmt-" ++ show n ++ " ------------------------------------------"
     (print . vertexStmt) (G.root g)
     let locals =
+          -- constants
           [ stmtRes c
           | Vertex {vertexStmt = c@CompStmt {stmtDetails = StmtCon{}}} <-
+              succs g (G.root g)
+          ] ++
+          -- function calls
+          [ stmtRes c
+          | Vertex {vertexStmt = c@CompStmt {stmtDetails = StmtLam{}}} <-
               succs g (G.root g)
           ]
     unless (null locals) $ do

--- a/Debug/Hoed/Console.hs
+++ b/Debug/Hoed/Console.hs
@@ -227,17 +227,13 @@ printStmts' gs = do
       "--- stmt-" ++ show n ++ " ------------------------------------------"
     (print . vertexStmt) (G.root g)
     let locals =
-          [ (stmtLabel, c)
-          | Vertex {vertexStmt = CompStmt {stmtDetails = StmtCon c, stmtLabel}} <-
+          [ stmtRes c
+          | Vertex {vertexStmt = c@CompStmt {stmtDetails = StmtCon{}}} <-
               succs g (G.root g)
           ]
     unless (null locals) $ do
       putStrLn "  where"
-      forM_ (succs g (G.root g)) $ \v ->
-        case v of
-          Vertex {vertexStmt = CompStmt {stmtDetails = StmtCon c, stmtLabel}} ->
-            putStrLn ("    " ++ stmtLabel ++ " = " ++ c)
-          _ -> return ()
+      mapM_ (putStrLn . ("    " ++)) locals
   putStrLn
     "--------------------------------------------------------------------"
 

--- a/Debug/Hoed/Observe.lhs
+++ b/Debug/Hoed/Observe.lhs
@@ -155,15 +155,6 @@ constrainBase x c | x == c = x
                   | otherwise = error $ show x ++ " constrained by " ++ show c
 \end{code}
 
-
-\begin{code}
-#if __GLASGOW_HASKELL__ >= 710
-instance {-# OVERLAPPABLE #-} Observable a where 
-  observer = observeOpaque "<?>"
-  constrain _ _ = error "contrained by untraced value"
-#endif
-\end{code}
-
 A type generic definition of constrain
 
 \begin{code}

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -13,6 +13,7 @@ module Debug.Hoed.Render
 ,rmEntrySet
 ,simplifyCDSSet
 ,noNewlines
+,sortOn
 ) where
 import           Control.Arrow
 import           Data.Array               as Array

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -2,7 +2,6 @@
 -- This file is part of the Haskell debugger Hoed.
 --
 -- Copyright (c) Maarten Faddegon, 2014
-{-# LANGUAGE CPP           #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Debug.Hoed.Render
@@ -18,23 +17,13 @@ module Debug.Hoed.Render
 import           Control.Arrow
 import           Data.Array               as Array
 import           Data.Char                (isAlpha)
-import           Data.List(sort,sortBy,nub
-#if __GLASGOW_HASKELL__ >= 710
-                          , sortOn
-#endif
-                          )
+import           Data.List(sort,sortBy,nub)
+import           Debug.Hoed.Compat
 import           Debug.Hoed.Observe
 import           GHC.Generics
 import           Prelude                  hiding (lookup)
 import           Text.PrettyPrint.FPretty hiding (sep)
 
-#if __GLASGOW_HASKELL__ < 710
-sortOn :: Ord b => (a -> b) -> [a] -> [a]
-sortOn f  = map snd . sortOn' fst .  map (\x -> (f x, x))
-
-sortOn' :: Ord b => (a -> b) -> [a] -> [a]
-sortOn' f = sortBy (\x y -> compare (f x) (f y))
-#endif
 
 ------------------------------------------------------------------------
 -- The CompStmt type

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ImplicitParams    #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 -- This file is part of the Haskell debugger Hoed.
 --
@@ -56,8 +55,8 @@ data StmtDetails
   deriving (Generic)
 
 stmtRes :: CompStmt -> String
-stmtRes CompStmt {stmtDetails = StmtLam x}     = x
-stmtRes CompStmt {stmtDetails = StmtCon x, ..} = stmtLabel ++ " = " ++ x
+stmtRes CompStmt {stmtDetails = StmtLam x} = x
+stmtRes CompStmt {stmtDetails = StmtCon x} = x
 
 instance Show CompStmt where
   show = stmtRes
@@ -99,7 +98,7 @@ renderNamedTop name observeUid (OutData cds) = map f pairs
       StmtLam $ pretty ?statementWidth $ renderNamedFn name (args, res)
     f (_, cons, Nothing) =
       CompStmt name observeUid $
-      StmtCon $ pretty ?statementWidth $ renderSet' 0 False cons
+      StmtCon $ pretty ?statementWidth $ renderNamedCons name cons
     pairs = (nubSorted . sortOn argAndRes) pairs'
     pairs' = findFn [cds]
     argAndRes (arg, res, _) = (arg, res)
@@ -241,6 +240,12 @@ renderFn (args, res)
                  "-> " <> renderSet' 0 False res
                 )
                )
+
+renderNamedCons :: String -> CDSSet -> Doc
+renderNamedCons name cons
+  = text name <> nest 2
+     ( sep <> grp (text "= " <> renderSet' 0 False cons)
+     )
 
 renderNamedFn :: String -> ([CDSSet],CDSSet) -> Doc
 renderNamedFn name (args,res)

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 -- This file is part of the Haskell debugger Hoed.
 --
 -- Copyright (c) Maarten Faddegon, 2014
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric     #-}
 
 module Debug.Hoed.Render
 (CompStmt(..)
@@ -20,7 +21,7 @@ module Debug.Hoed.Render
 import           Control.Arrow
 import           Data.Array               as Array
 import           Data.Char                (isAlpha)
-import           Data.List(sort,sortBy,nub)
+import           Data.List                (nub, sort, sortBy)
 import           Debug.Hoed.Compat
 import           Debug.Hoed.Observe
 import           GHC.Generics
@@ -54,8 +55,8 @@ data StmtDetails
   deriving (Generic)
 
 stmtRes :: CompStmt -> String
-stmtRes CompStmt {stmtDetails = StmtLam x} = x
-stmtRes CompStmt {stmtDetails = StmtCon x} = x
+stmtRes CompStmt {stmtDetails = StmtLam x}     = x
+stmtRes CompStmt {stmtDetails = StmtCon x, ..} = stmtLabel ++ " = " ++ x
 
 instance Show CompStmt where
   show = stmtRes

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -173,7 +173,8 @@ render prec par (CDSCons _ "," cdss) | length cdss > 0 =
                             (map renderSet cdss) <>
                 text ")")
 render prec par (CDSCons _ name cdss)
-  | (not . isAlpha . head) name && length cdss > 1 = -- render as infix
+  | _:_ <- name
+  , (not . isAlpha . head) name && length cdss > 1 = -- render as infix
         paren (prec /= 0)
                   (grp
                     (renderSet' 10 False (head cdss)

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -251,7 +251,7 @@ renderNamedFn :: String -> ([CDSSet],CDSSet) -> Doc
 renderNamedFn name (args,res)
   = text name <> nest 2
      ( sep <> foldr (\ a b -> grp (renderSet' 10 False a) <> sep <> b) nil args
-       <> sep <> grp ("= " <> renderSet' 0 False res)
+       <> sep <> grp ("= " <> align(renderSet' 0 False res))
      )
 
 -- | Reconstructs functional values from a CDSSet.

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -1,7 +1,8 @@
 -- This file is part of the Haskell debugger Hoed.
 --
 -- Copyright (c) Maarten Faddegon, 2014
-{-# LANGUAGE CPP, DeriveGeneric #-}
+{-# LANGUAGE CPP           #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Debug.Hoed.Render
 (CompStmt(..)
@@ -12,20 +13,20 @@ module Debug.Hoed.Render
 ,simplifyCDSSet
 ,noNewlines
 ) where
-import Debug.Hoed.EventForest
+import           Debug.Hoed.EventForest
 
-import Text.PrettyPrint.FPretty hiding (sep)
-import Prelude hiding(lookup)
-import Debug.Hoed.Observe
-import Data.List(sort,sortBy,partition,nub
+import           Data.Array               as Array
+import           Data.Char                (isAlpha)
+import           Data.Graph.Libgraph
+import           Data.List(sort,sortBy,partition,nub
 #if __GLASGOW_HASKELL__ >= 710
-                , sortOn
+                          , sortOn
 #endif
-                )
-import Data.Graph.Libgraph
-import Data.Array as Array
-import Data.Char(isAlpha)
-import GHC.Generics
+                          )
+import           Debug.Hoed.Observe
+import           GHC.Generics
+import           Prelude                  hiding (lookup)
+import           Text.PrettyPrint.FPretty hiding (sep)
 
 #if __GLASGOW_HASKELL__ < 710
 sortOn :: Ord b => (a -> b) -> [a] -> [a]
@@ -97,9 +98,9 @@ renderNamedTop name observeUid(OutData cds)
 
 -- local nub for sorted lists
 nubSorted :: Eq a => [a] -> [a]
-nubSorted []                  = []
+nubSorted []        = []
 nubSorted (a:a':as) | a == a' = nub (a' : as)
-nubSorted (a:as)              = a : nub as
+nubSorted (a:as)    = a : nub as
 
 -- %************************************************************************
 -- %*                                                                   *
@@ -217,9 +218,9 @@ renderSet' prec par cdss                   =
         findFn_noUIDs c = map (\(a,r,_) -> (a,r)) (findFn c)
         pairs = nub (sort (findFn_noUIDs cdss))
         -- local nub for sorted lists
-        nub []                  = []
+        nub []        = []
         nub (a:a':as) | a == a' = nub (a' : as)
-        nub (a:as)              = a : nub as
+        nub (a:as)    = a : nub as
 
 renderFn :: ([CDSSet],CDSSet) -> Doc
 renderFn (args, res)
@@ -274,7 +275,7 @@ simplifyCDS (CDSCons _ "throw"
 simplifyCDS cons@(CDSCons i str sets) =
         case spotString [cons] of
           Just str | not (null str) -> CDSCons 0 (show str) []
-          _ -> CDSCons 0 str (map simplifyCDSSet sets)
+          _        -> CDSCons 0 str (map simplifyCDSSet sets)
 
 simplifyCDS (CDSFun i a b) = CDSFun i (simplifyCDSSet a) (simplifyCDSSet b)
 
@@ -290,7 +291,7 @@ spotString [CDSCons _ ":"
            ]
         = do { ch <- case reads str of
                        [(ch,"")] -> return ch
-                       _ -> Nothing
+                       _         -> Nothing
              ; more <- spotString rest
              ; return (ch : more)
              }
@@ -319,7 +320,7 @@ cdsToOutput    fn@(CDSFun {}) = OutData fn
 
 nil = Text.PrettyPrint.FPretty.empty
 grp = Text.PrettyPrint.FPretty.group
-brk = softbreak -- Nothing, if the following still fits on the current line, otherwise newline. 
-sep = softline  -- A space, if the following still fits on the current line, otherwise newline. 
+brk = softbreak -- Nothing, if the following still fits on the current line, otherwise newline.
+sep = softline  -- A space, if the following still fits on the current line, otherwise newline.
 sp :: Doc
 sp = text " "   -- A space, always.

--- a/Debug/Hoed/Serialize.hs
+++ b/Debug/Hoed/Serialize.hs
@@ -15,7 +15,7 @@ import Debug.Hoed.Observe
 import Prelude hiding (lookup,Right)
 import qualified Prelude as Prelude
 import Debug.Hoed.CompTree
-import Debug.Hoed.Render(CompStmt(..))
+import Debug.Hoed.Render(CompStmt(..), StmtDetails(..))
 import Data.Serialize
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -31,6 +31,7 @@ instance Serialize Vertex
 instance Serialize Judgement
 instance Serialize AssistedMessage
 instance Serialize CompStmt
+instance Serialize StmtDetails
 instance Serialize Parent
 instance Serialize Event
 instance Serialize Change

--- a/Debug/Hoed/TH.hs
+++ b/Debug/Hoed/TH.hs
@@ -69,7 +69,7 @@ obs decs = do
 debug :: Q [Dec] -> Q [Dec]
 debug q = do
   decs <- q
-  names <- sequence [ (n,) <$> newName(nameBase n ++ "'") | FunD n _ <- decs]
+  names <- sequence [ (n,) <$> newName(nameBase n ++ "Debug") | FunD n _ <- decs]
   fmap concat $ forM decs $ \dec ->
     case dec of
       FunD n clauses -> do
@@ -103,6 +103,7 @@ adjustSig name (ForallT vars ctxt typ) = do
   return $
     SigD name $
     ForallT vars (nub $ map (addConstraint ''Observable . (:[]) . VarT) vs ++ ctxt) typ
+adjustSig name other = adjustSig name $ ForallT [] [] other
 
 adjustValD decl@ValD{} = transformBi adjustPat decl
 adjustValD other       = other

--- a/Debug/Hoed/TH.hs
+++ b/Debug/Hoed/TH.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TupleSections   #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Debug.Hoed.TH where
+module Debug.Hoed.TH (debug, obs) where
 
 import           Control.Monad
 import           Data.Generics.Uniplate.Data

--- a/Debug/Hoed/TH.hs
+++ b/Debug/Hoed/TH.hs
@@ -5,6 +5,7 @@ module Debug.Hoed.TH where
 
 import           Control.Monad
 import           Debug.Hoed
+import           Debug.Hoed.Compat
 import           Language.Haskell.TH
 
 -- | A handy TH wrapper for observing functions.

--- a/Debug/Hoed/TH.hs
+++ b/Debug/Hoed/TH.hs
@@ -4,9 +4,12 @@
 module Debug.Hoed.TH where
 
 import           Control.Monad
+import           Data.Generics.Uniplate.Data
+import           Data.List                   (group, sort, (\\))
 import           Debug.Hoed
 import           Debug.Hoed.Compat
 import           Language.Haskell.TH
+import           Language.Haskell.TH.Syntax
 
 -- | A handy TH wrapper for observing functions.
 --
@@ -39,7 +42,72 @@ obs decs = do
             nb = nameBase n
         newDecl <- funD n [clause [] (normalB [| observe nb $(varE n')|]) []]
         return [newDecl, FunD n' xx]
-      SigD n ty | Just n' <- lookup n names ->
-        return [dec, SigD n' ty]
+      SigD n ty | Just n' <- lookup n names -> do
+        dec' <- adjustSig n ty
+        return [dec']
       _ ->
         return [dec]
+
+-- | A handy TH wrapper for debugging functions, offering more information than 'obs'
+--
+--   @
+--   debug [d|
+--     quicksort [] = []
+--     quicksort (x:xs) = quicksort lt ++ [x] ++ quicksort gt
+--         where (lt, gt) = partition (<= x) xs
+--           |]
+--   @
+--
+--   expands to:
+--
+--   @
+--   quicksort = observe "quicksort" quicksort'
+--   quicksort' [] = []
+--   quicksort' (x:xs) = quicksort lt ++ [x] ++ quicksort gt
+--         where (observe "lt" -> lt, observe "lt" -> gt) = partition (<= x) xs
+--
+debug :: Q [Dec] -> Q [Dec]
+debug q = do
+  decs <- q
+  names <- sequence [ (n,) <$> newName(nameBase n ++ "'") | FunD n _ <- decs]
+  fmap concat $ forM decs $ \dec ->
+    case dec of
+      FunD n clauses -> do
+        let Just n' = lookup n names
+            nb = nameBase n
+        newDecl <- funD n [clause [] (normalB [| observe nb $(varE n')|]) []]
+        let clauses' = transformBi adjustValD clauses
+        return [newDecl, FunD n' clauses']
+      SigD n ty | Just n' <- lookup n names -> do
+        dec' <- adjustSig n ty
+        return [dec']
+      _ ->
+        return [dec]
+
+nubOrd :: Ord a => [a] -> [a]
+nubOrd = map head . group . sort
+
+----------------------------------------------------------
+-- With a little help from Neil Mitchell's debug package
+
+-- | List all the type variables of kind * (or do the best you can)
+kindStar :: Type -> Q [Name]
+-- in Q so we should be able to use 'reify' to do a better job
+kindStar t = return $
+    nubOrd [x | VarT x <- universe t] \\     -- find all variables
+    nubOrd [x | AppT (VarT x) _ <- universe t] -- delete the "obvious" ones
+
+-- try and shove in a "Observable a =>" if we can
+adjustSig name (ForallT vars ctxt typ) = do
+  vs <- kindStar typ
+  return $
+    SigD name $
+    ForallT vars (nubOrd $ map (AppT (ConT ''Observable) . VarT) vs ++ ctxt) typ
+
+adjustValD decl@ValD{} = transformBi adjustPat decl
+adjustValD other       = other
+
+adjustPat (VarP x) = ViewP (VarE 'observe `AppE` toLit x) (VarP x)
+adjustPat x        = x
+
+toLit (Name (OccName x) _) = LitE $ StringL x

--- a/Debug/Hoed/TH.hs
+++ b/Debug/Hoed/TH.hs
@@ -5,7 +5,7 @@ module Debug.Hoed.TH where
 
 import           Control.Monad
 import           Data.Generics.Uniplate.Data
-import           Data.List                   (group, sort, (\\))
+import           Data.List                   (group, nub, sort, (\\))
 import           Debug.Hoed
 import           Debug.Hoed.Compat
 import           Language.Haskell.TH
@@ -102,7 +102,7 @@ adjustSig name (ForallT vars ctxt typ) = do
   vs <- kindStar typ
   return $
     SigD name $
-    ForallT vars (nubOrd $ map (AppT (ConT ''Observable) . VarT) vs ++ ctxt) typ
+    ForallT vars (nub $ map (addConstraint ''Observable . (:[]) . VarT) vs ++ ctxt) typ
 
 adjustValD decl@ValD{} = transformBi adjustPat decl
 adjustValD other       = other

--- a/Debug/Hoed/TH.hs
+++ b/Debug/Hoed/TH.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE TupleSections   #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Debug.Hoed.TH where
+
+import           Control.Monad
+import           Debug.Hoed
+import           Language.Haskell.TH
+
+-- | A handy TH wrapper for observing functions.
+--
+--   @
+--   obs [d|
+--     trimPat :: Exp S -> Pat S -> Pat S
+--     trimPat vs = filterPat ((`Set.member` freeVars vs) . void)
+--       |]
+--   @
+--
+--   is equivalent to:
+--
+--   @
+--   trimPat = observe "trimPat" trimPat'
+--   trimPat' vs = filterPat ....
+--   @
+--
+--   'obs' accepts multiple declarations, and all the functions
+--   inside will be wrapped as above, while the rest of declarations
+--   will stay unchanged. As such it can be used to observe entire modules.
+--
+obs :: Q [Dec] -> Q [Dec]
+obs decs = do
+  decs <- decs
+  names <- sequence [ (n,) <$> newName(nameBase n ++ "Obs") | FunD n _ <- decs]
+  fmap concat $ forM decs $ \dec ->
+    case dec of
+      FunD n xx -> do
+        let Just n' = lookup n names
+            nb = nameBase n
+        newDecl <- funD n [clause [] (normalB [| observe nb $(varE n')|]) []]
+        return [newDecl, FunD n' xx]
+      SigD n ty | Just n' <- lookup n names ->
+        return [dec, SigD n' ty]
+      _ ->
+        return [dec]

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -1,5 +1,5 @@
 name:                Hoed
-version:             0.4.0
+version:             0.4.1
 synopsis:            Lightweight algorithmic debugging.
 description:
     Hoed is a tracer and debugger for the programming language Haskell.
@@ -23,13 +23,13 @@ source-repository head
   location: https://github.com/MaartenFaddegon/Hoed.git
 
 library
-  exposed-modules:     Debug.Hoed
+  exposed-modules:     Debug.Hoed.Observe
+                       , Debug.Hoed
                        , Debug.Hoed.TH
                        , Debug.NoHoed
                        , Debug.Hoed.CompTree
                        , Debug.Hoed.Render
-  other-modules:       Debug.Hoed.Observe
-                       , Debug.Hoed.Compat
+  other-modules:       Debug.Hoed.Compat
                        , Debug.Hoed.EventForest
                        , Debug.Hoed.ReadLine
                        , Debug.Hoed.Console

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -48,5 +48,6 @@ library
                        , cereal, bytestring
                        , template-haskell
                        , time
+                       , uniplate
   default-language:    Haskell2010
   cpp-options:         -DDEBUG

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -41,7 +41,7 @@ library
                        , process
                        , filepath
                        , libgraph == 1.14
-                       , regex-posix
+                       , regex-tdfa
                        , mtl
                        , directory
                        , cereal, bytestring

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -24,6 +24,7 @@ source-repository head
 
 library
   exposed-modules:     Debug.Hoed
+                       , Debug.Hoed.TH
                        , Debug.NoHoed
   other-modules:       Debug.Hoed.Observe
                        , Debug.Hoed.EventForest
@@ -44,5 +45,6 @@ library
                        , mtl
                        , directory
                        , cereal, bytestring
+                       , template-haskell
                        , time
   default-language:    Haskell2010

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -48,3 +48,4 @@ library
                        , template-haskell
                        , time
   default-language:    Haskell2010
+  cpp-options:         -DDEBUG

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -47,6 +47,7 @@ library
                        , directory
                        , cereal, bytestring
                        , template-haskell
+                       , terminal-size
                        , time
                        , uniplate
   default-language:    Haskell2010

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -26,11 +26,11 @@ library
   exposed-modules:     Debug.Hoed
                        , Debug.Hoed.TH
                        , Debug.NoHoed
+                       , Debug.Hoed.CompTree
+                       , Debug.Hoed.Render
   other-modules:       Debug.Hoed.Observe
                        , Debug.Hoed.Compat
                        , Debug.Hoed.EventForest
-                       , Debug.Hoed.CompTree
-                       , Debug.Hoed.Render
                        , Debug.Hoed.ReadLine
                        , Debug.Hoed.Console
                        , Debug.Hoed.Prop

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -27,6 +27,7 @@ library
                        , Debug.Hoed.TH
                        , Debug.NoHoed
   other-modules:       Debug.Hoed.Observe
+                       , Debug.Hoed.Compat
                        , Debug.Hoed.EventForest
                        , Debug.Hoed.CompTree
                        , Debug.Hoed.Render

--- a/Text/PrettyPrint/FPretty.hs
+++ b/Text/PrettyPrint/FPretty.hs
@@ -122,6 +122,7 @@ import qualified Data.Sequence as Dequeue (empty)
   -- on Functional Data Structures.
   -- Efficiency probably similar, but Data.Sequence is part of the standard Haskell 
   -- libraries.
+import Data.String
 
 infixr 6 <>,<+>
 infixr 5 <$>,<$$>,</>,<//>
@@ -247,6 +248,9 @@ data Doc = Text Int String  -- includes length of text string
          | Nest Int Doc     -- increase current indentation
          | Align Int Doc    -- set indentation to current column plus increment
   deriving Show
+
+instance IsString Doc where
+  fromString = text
 
 empty = Nil
 text t = Text (length t) t


### PR DESCRIPTION
Last week at the office @ndmitchell was looking for a debugging tool and I tried to demo the new version of Hoed. Unfortunately it didn't work very well, we couldn't observe even a simple example. 

These changes are a first stab at improving the first experience with Hoed, the main bits are:
- Fixed a couple of odd bugs (head of empty list, empty regex, indexing errors, incomplete pattern matches)
- Fixed regexes in Windows
- Re-added the TH primitive that I contributed to the previous version of Hoed
- Added a new command to show the list of available observations 
- Made a couple of minor performance fixes (avoid nub and use atomicModify instead of locks)

There is still a lot of work to do: 
- The documentation and the haddocks still refer to the GUI instead of the new CLI. 
- The CLI itself needs a bit of love to become as usable as the GUI.
- The original Hood had the ability to do nested observations, but Hoed removed that.

Apologies for the large number of changes. Let me know if there is any way I can make them easier to review.