### PR TITLE
Fix undesired edges from nested constant observations

### DIFF
--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -151,7 +151,6 @@ module Debug.Hoed
   , Observable(..)
   , (<<)
   , thunk
-  , nothunk
   , send
   , observeOpaque
   , observeBase

--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -403,10 +403,6 @@ traceInfo trc = foldl loop s0 trc
                                      $ if loc then addDependency e
                                                 $ start e s else pause e s
 
-                        NoEnter{} -> if not . corToCons cs $ e then s else cpyTopLvlFun e
-                                     $ if loc then addDependency e
-                                                $ start e s else pause e s
-
                         -- Span end
                         Cons{} ->  cpyTopLvlFun e
                                    . setLocation e (const loc)

--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -277,7 +277,7 @@ start e s = m s{computations = cs}
   where i  = getTopLvlFun e s
         cs = Computing i : computations s
 #if defined(TRANSCRIPT)
-        m  = addMessage e $ "Start computation " ++ show i ++ ": " ++ showCs cs
+        m  = addMessage e $ "Start computation " ++ show i ++ ": " ++ show cs
 #else
         m = id
 #endif
@@ -292,7 +292,7 @@ stop e s = m s{computations = cs}
         deleteFirst (s:ss) | isSpan i s = ss
                            | otherwise  = s : deleteFirst ss
 #if defined(TRANSCRIPT)
-        m  = addMessage e $ "Stop computation " ++ show i ++ ": " ++ showCs cs
+        m  = addMessage e $ "Stop computation " ++ show i ++ ": " ++ show cs
 #else
         m = id
 #endif
@@ -309,7 +309,7 @@ pause e s = m s{computations=cs}
         isComputingI (Computing j) = i == j
         isComputingI _             = False
 #if defined(TRANSCRIPT)
-        m  = addMessage e $ "Pause computation " ++ show i ++ ": " ++ showCs cs
+        m  = addMessage e $ "Pause computation " ++ show i ++ ": " ++ show cs
 #else
         m = id
 #endif
@@ -325,7 +325,7 @@ resume e s = m s{computations=cs}
         isPausedI (Paused j) = i == j
         isPausedI _          = False
 #if defined(TRANSCRIPT)
-        m = addMessage e $ "Resume computation " ++ show i ++ ": " ++ showCs cs
+        m = addMessage e $ "Resume computation " ++ show i ++ ": " ++ show cs
 #else
         m = id
 #endif
@@ -339,7 +339,7 @@ activeComputations s = map getSpanUID . filter isActive $ computations s
 ------------------------------------------------------------------------------------------------------------------------
 
 addDependency :: Event -> TraceInfo -> TraceInfo
-addDependency _ s = m s{dependencies = case d of (Just d') -> d':dependencies s; Nothing -> dependencies s}
+addDependency e s = m s{dependencies = case d of (Just d') -> d':dependencies s; Nothing -> dependencies s}
 
   where d = case activeComputations s of
               []      -> Nothing

--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -178,8 +178,6 @@ data TraceInfo = TraceInfo
   , messages     :: IntMap String
                    -- stored depth of the stack for every event
 #endif
-  , storedStack  :: IntMap [UID]
-                   -- reference from parent UID and position to previous stack
   , dependencies :: [(UID,UID)]
   }                -- the result
 
@@ -388,7 +386,7 @@ traceInfo trc = foldl loop s0 trc
 #if defined(TRANSCRIPT)
                        IntMap.empty
 #endif
-                       IntMap.empty []
+                       []
 
         cs :: ConsMap
         cs = mkConsMap trc

--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -264,6 +264,9 @@ instance Show Span where
   show (Computing i) = show i
   show (Paused i)    = "(" ++ show i ++ ")"
 
+toPaused (Computing i) = Paused i
+toPaused it@Paused{} = it
+
 getSpanUID :: Span -> UID
 getSpanUID (Computing j) = j
 getSpanUID (Paused j)    = j
@@ -304,7 +307,7 @@ pause e s = m s{computations=cs}
   where i  = getTopLvlFun e s
         cs = case cs_post of
                []      -> cs_pre
-               (_:cs') -> cs_pre ++ Paused i : cs'
+               (_:cs') -> map toPaused cs_pre ++ Paused i : cs'
         (cs_pre,cs_post)           = break isComputingI (computations s)
         isComputingI (Computing j) = i == j
         isComputingI _             = False

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -158,7 +158,6 @@ eventsToCDS pairs = getChild 0 0
         (Observe str i) -> let chd = getChild node 0
                                in CDSNamed str (getId chd i) chd
         Enter             -> CDSEntered node
-        NoEnter           -> CDSTerminated node
         Fun                 -> CDSFun node (getChild node 0) (getChild node 1)
         (Cons portc cons)
                             -> CDSCons node cons

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -51,4 +51,3 @@ library
                        , time
                        , uniplate
   default-language:    Haskell2010
-  cpp-options:         -DDEBUG


### PR DESCRIPTION
Currently 'pause e' finds and pauses the computation of the top level function 'f' for 'e'. If we change 'pause e' to also pause all the computations below 'f' in the stack, the problem with the nested observations goes away.

This is an alternative to my previous pull request. If you can review this change and convince yourself that it works, I'd much prefer to go with this fix. 

If you couldn't find the time to review this (or convince yourself that it works) I would be unable to continue the work on `debug-hoed`...