### PR TITLE
Performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ matrix:
   #- env: BUILD=cabal GHCVER=7.4.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
   #  compiler: ": #GHC 7.4.2"
   #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.6.3"
-    addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #   compiler: ": #GHC 7.6.3"
+  #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 7.8.4"
     addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ matrix:
   # - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
   #   compiler: ": #GHC 7.6.3"
   #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.8.4"
-    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #   compiler: ": #GHC 7.8.4"
+  #   addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 7.10.3"
     addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
@@ -69,9 +69,9 @@ matrix:
     compiler: ": #stack default"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-2"
-    compiler: ": #stack 7.8.4"
-    addons: {apt: {packages: [libgmp-dev]}}
+  # - env: BUILD=stack ARGS="--resolver lts-2"
+  #   compiler: ": #stack 7.8.4"
+  #   addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-3"
     compiler: ": #stack 7.10.2"

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -336,9 +336,8 @@ runO' HoedOptions{..} program = let ?statementWidth = prettyWidth in do
   condPutStrLn verbose $ "\n=== program terminated (" ++ show programTime ++ " seconds) ==="
   condPutStrLn verbose"Please wait while the computation tree is constructed..."
 
-  let !cdss1 = eventsToCDS events
-      cdss2 = simplifyCDSSet cdss1
-      !eqs  = force $ renderCompStmts cdss2
+  let !cdss = eventsToCDS events
+      !eqs  = force $ renderCompStmts cdss
       e    = length events
       frt  = mkEventForest events
       ti   = traceInfo e (reverse events)

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -336,8 +336,7 @@ runO' HoedOptions{..} program = let ?statementWidth = prettyWidth in do
   condPutStrLn verbose $ "\n=== program terminated (" ++ show programTime ++ " seconds) ==="
   condPutStrLn verbose"Please wait while the computation tree is constructed..."
 
-  let !cdss  = eventsToCDS events
-      cdss1 = rmEntrySet cdss
+  let !cdss1 = eventsToCDS events
       cdss2 = simplifyCDSSet cdss1
       !eqs  = force $ renderCompStmts cdss2
       e    = length events

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -337,9 +337,13 @@ runO' HoedOptions{..} program = let ?statementWidth = prettyWidth in do
   condPutStrLn verbose $ "\n=== program terminated (" ++ show programTime ++ " seconds) ==="
   condPutStrLn verbose"Please wait while the computation tree is constructed..."
 
+  let e = length events
+
+  condPutStrLn verbose "\n=== Statistics ===\n"
+  condPutStrLn verbose $ show e ++ " events"
+
   let !cdss = eventsToCDS events
       !eqs  = force $ renderCompStmts cdss
-      e    = length events
       ti   = traceInfo e (reverse events)
       !ds  = force $ dependencies ti
       ct  = mkCompTree eqs ds
@@ -353,10 +357,8 @@ runO' HoedOptions{..} program = let ?statementWidth = prettyWidth in do
   writeFile ".Hoed/Transcript" (getTranscript events ti)
 #endif
 
-  condPutStrLn verbose "\n=== Statistics ===\n"
   let n  = length eqs
       b  = fromIntegral (length . arcs $ ct ) / fromIntegral ((length . vertices $ ct) - (length . leafs $ ct))
-  condPutStrLn verbose $ show e ++ " events"
   condPutStrLn verbose $ show n ++ " computation statements"
   condPutStrLn verbose $ show ((length . vertices $ ct) - 1) ++ " nodes + 1 virtual root node in the computation tree"
   condPutStrLn verbose $ show (length . arcs $ ct) ++ " edges in computation tree"

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -333,7 +333,7 @@ runO' HoedOptions{..} program = let ?statementWidth = prettyWidth in do
   condPutStrLn verbose "=== program output ===\n"
   events <- debugO program
   t2 <- getTime Monotonic
-  let programTime = fromIntegral(toNanoSecs(diffTimeSpec t1 t2)) * 1e-9
+  let programTime = toSecs(diffTimeSpec t1 t2)
   condPutStrLn verbose $ "\n=== program terminated (" ++ show programTime ++ " seconds) ==="
   condPutStrLn verbose"Please wait while the computation tree is constructed..."
 
@@ -363,9 +363,12 @@ runO' HoedOptions{..} program = let ?statementWidth = prettyWidth in do
   condPutStrLn verbose $ "computation tree has a branch factor of " ++ show b ++ " (i.e the average number of children of non-leaf nodes)"
 
   t3 <- getTime Monotonic
-  let compTime = fromIntegral(toNanoSecs(diffTimeSpec t2 t3)) * 1e-9
+  let compTime = toSecs(diffTimeSpec t2 t3)
   condPutStrLn verbose $ "\n=== Debug Session (" ++ show compTime ++ " seconds) ===\n"
   return $ HoedAnalysis events ct
+    where
+       toSecs :: TimeSpec -> Double
+       toSecs spec = fromIntegral(sec spec) + fromIntegral(nsec spec) * 1e-9
 
 -- | Trace and write computation tree to file. Useful for regression testing.
 logO :: FilePath -> IO a -> IO ()

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ImplicitParams  #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -188,7 +189,6 @@ module Debug.Hoed
 import Control.DeepSeq
 import           Debug.Hoed.CompTree
 import           Debug.Hoed.Console
-import           Debug.Hoed.EventForest
 import           Debug.Hoed.Observe
 import           Debug.Hoed.Prop
 import           Debug.Hoed.Render
@@ -322,6 +322,7 @@ data HoedOptions = HoedOptions
   , prettyWidth :: Int
   }
 
+defaultHoedOptions :: HoedOptions
 defaultHoedOptions = HoedOptions Silent 110
 
 -- |Entry point giving you access to the internals of Hoed. Also see: runO.
@@ -339,7 +340,6 @@ runO' HoedOptions{..} program = let ?statementWidth = prettyWidth in do
   let !cdss = eventsToCDS events
       !eqs  = force $ renderCompStmts cdss
       e    = length events
-      frt  = mkEventForest events
       ti   = traceInfo e (reverse events)
       !ds  = force $ dependencies ti
       ct  = mkCompTree eqs ds

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -337,28 +337,26 @@ runO' HoedOptions{..} program = let ?statementWidth = prettyWidth in do
   condPutStrLn verbose"Please wait while the computation tree is constructed..."
 
   let cdss  = eventsToCDS events
-  let cdss1 = rmEntrySet cdss
-  let cdss2 = simplifyCDSSet cdss1
-  let eqs   = renderCompStmts cdss2
-
-  let frt  = mkEventForest events
-      ti   = traceInfo (reverse events)
-      ds   = dependencies ti
-      ct   = mkCompTree eqs ds
+      cdss1 = rmEntrySet cdss
+      cdss2 = simplifyCDSSet cdss1
+      eqs   = renderCompStmts cdss2
+      e    = length events
+      frt  = mkEventForest events
+      ti   = traceInfo e (reverse events)
+      ds  = dependencies ti
+      ct  = mkCompTree eqs ds
 
 #if defined(DEBUG)
   writeFile ".Hoed/Events"     (unlines . map show . reverse $ events)
   writeFile ".Hoed/Cdss"       (unlines . map show $ cdss2)
   writeFile ".Hoed/Eqs"        (unlines . map show $ eqs)
-  writeFile ".Hoed/compTree"   (unlines . map show $ eqs)
 #endif
 #if defined(TRANSCRIPT)
   writeFile ".Hoed/Transcript" (getTranscript events ti)
 #endif
 
   condPutStrLn verbose "\n=== Statistics ===\n"
-  let e  = length events
-      n  = length eqs
+  let n  = length eqs
       b  = fromIntegral (length . arcs $ ct ) / fromIntegral ((length . vertices $ ct) - (length . leafs $ ct))
   condPutStrLn verbose $ show e ++ " events"
   condPutStrLn verbose $ show n ++ " computation statements"

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -185,7 +185,7 @@ module Debug.Hoed
   , Generic
   ) where
 
-
+import Control.DeepSeq
 import           Debug.Hoed.CompTree
 import           Debug.Hoed.Console
 import           Debug.Hoed.EventForest
@@ -336,14 +336,14 @@ runO' HoedOptions{..} program = let ?statementWidth = prettyWidth in do
   condPutStrLn verbose $ "\n=== program terminated (" ++ show programTime ++ " seconds) ==="
   condPutStrLn verbose"Please wait while the computation tree is constructed..."
 
-  let cdss  = eventsToCDS events
+  let !cdss  = eventsToCDS events
       cdss1 = rmEntrySet cdss
       cdss2 = simplifyCDSSet cdss1
-      eqs   = renderCompStmts cdss2
+      !eqs  = force $ renderCompStmts cdss2
       e    = length events
       frt  = mkEventForest events
       ti   = traceInfo e (reverse events)
-      ds  = dependencies ti
+      !ds  = force $ dependencies ti
       ct  = mkCompTree eqs ds
 
 #if defined(DEBUG)

--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -347,10 +347,10 @@ moveRight SZ{right = SpanCons uid r, ..} = Just $ SZ (SpanCons cursorUID left) u
 pauseSpan :: UID -> SpanZipper -> SpanZipper
 pauseSpan uid sz
   | x  == uid = sz{cursorUID = negate uid}
-  | otherwise = pauseSpan uid $ fromMaybe err $ moveRight sz{cursorUID = if x>0 then negate x else x}
+  | otherwise = pauseSpan uid $ fromMaybe sz' $ moveRight sz{cursorUID = if x>0 then negate x else x}
   where
     x = cursorUID sz
-    err = error $ unwords ["pauseSpan", show uid, show sz]
+    sz' = assert (Computing uid `notElem` toList (left sz)) sz
 
 -- resumeSpan moves to the left, except when at the Top of the stack in which case it goes right
 resumeSpan :: UID -> SpanZipper -> SpanZipper

--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -436,8 +436,13 @@ mkConsMap l t =
       case change e of
         Cons {} -> do
           let p = eventParent e
-          assert (parentPosition p < 64) $
-            VM.unsafeModify v (`setBit` parentPosition p) (parentUID p - 1)
+#if __GLASGOW_HASKELL__ >= 800
+          VM.unsafeModify v (`setBit` parentPosition p) (parentUID p - 1)
+#else
+          let ix = parentUID p - 1
+          x <- VM.unsafeRead v ix
+          VM.unsafeWrite v ix (x `setBit` parentPosition p)
+#endif
         _ -> return ()
     return v
 

--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -53,7 +53,7 @@ import           Data.Graph.Libgraph
 import           Data.IntMap.Strict     (IntMap)
 import qualified Data.IntMap.Strict     as IntMap
 import           Data.IntSet            (IntSet)
-import           Data.List              (foldl')
+import           Data.List              (foldl', unfoldr)
 import           Data.Maybe
 import           Data.Semigroup
 import           Data.Vector.Mutable as VM (STVector)
@@ -289,10 +289,11 @@ data SpanList = SpanCons !UID !SpanList | SpanNil
 
 instance IsList SpanList where
   type Item SpanList = Span
-  toList SpanNil = []
-  toList (SpanCons uid rest)
-    | uid > 0 = Computing uid : toList rest
-    | otherwise = Paused (negate uid) : toList rest
+  toList = unfoldr f where
+    f SpanNil = Nothing
+    f (SpanCons uid rest)
+      | uid > 0   = Just (Computing uid, rest)
+      | otherwise = Just (Paused (negate uid), rest)
   fromList [] = SpanNil
   fromList (Paused uid : rest) = SpanCons (negate uid) $ fromList rest
   fromList (Computing uid : rest) = SpanCons uid $ fromList rest

--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -59,6 +59,7 @@ import           Data.Semigroup
 import           Data.Vector.Mutable as VM (STVector)
 import qualified Data.Vector.Generic.Mutable as VM
 import qualified Data.Vector.Unboxed    as U
+import           Data.Word
 import           GHC.Exts               (IsList (..))
 import           GHC.Generics
 import           Prelude                hiding (Right)

--- a/Debug/Hoed/Fields.hs
+++ b/Debug/Hoed/Fields.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+module Debug.Hoed.Fields where
+
+import GHC.Generics
+import GHC.Exts
+import GHC.TypeLits (ErrorMessage(..), TypeError)
+
+data Nat = Z | S Nat
+
+-- A constraint on the number of the constructors in a datatype
+type family FieldLimit (n :: Nat) a :: Constraint where
+  FieldLimit n (M1 c meta f) = FieldLimit n f
+  FieldLimit n (f :+: g)     = (FieldLimit n f, FieldLimit n g)
+  FieldLimit ('S n) (f :*: g) = FieldLimit n g
+  FieldLimit n U1 = ()
+  FieldLimit n V1 = ()
+  FieldLimit n (K1 _ _) = ()
+  FieldLimit n (URec _) = ()
+  FieldLimit 'Z f = TypeError ('Text "Hoed only handles constructors with 64 fields or less")

--- a/Debug/Hoed/Fields.hs
+++ b/Debug/Hoed/Fields.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -7,7 +8,10 @@ module Debug.Hoed.Fields where
 
 import GHC.Generics
 import GHC.Exts
+
+#if __GLASGOW_HASKELL__ > 710
 import GHC.TypeLits (ErrorMessage(..), TypeError)
+#endif
 
 data Nat = Z | S Nat
 
@@ -18,6 +22,8 @@ type family FieldLimit (n :: Nat) a :: Constraint where
   FieldLimit ('S n) (f :*: g) = FieldLimit n g
   FieldLimit n U1 = ()
   FieldLimit n V1 = ()
-  FieldLimit n (K1 _ _) = ()
-  FieldLimit n (URec _) = ()
+  FieldLimit n (K1 a b) = ()
+#if __GLASGOW_HASKELL__ > 710
+  FieldLimit n (URec a) = ()
   FieldLimit 'Z f = TypeError ('Text "Hoed only handles constructors with 64 fields or less")
+#endif

--- a/Debug/Hoed/Observe.lhs
+++ b/Debug/Hoed/Observe.lhs
@@ -1,5 +1,6 @@
 \begin{code}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -7,6 +8,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 
 \end{code}
@@ -93,6 +95,7 @@ import Control.Monad
 import Data.Array as Array
 import Data.List
 import Data.Char
+import Debug.Hoed.Fields
 import System.Environment
 
 import GHC.Generics
@@ -155,6 +158,7 @@ constrainBase x c | x == c = x
                   | otherwise = error $ show x ++ " constrained by " ++ show c
 \end{code}
 
+
 A type generic definition of constrain
 
 \begin{code}
@@ -181,7 +185,8 @@ Observing the children of Data types of kind *.
 \begin{code}
 
 -- Meta: data types
-instance (GObservable a) => GObservable (M1 D d a) where
+-- FieldLimit requires undecidable instances
+instance (FieldLimit ('S ('S ('S ('S ('S ('S 'Z)))))) a, GObservable a) => GObservable (M1 D d a) where
  gdmobserver m@(M1 x) cxt = M1 (gdmobserver x cxt)
  gdmObserveArgs = gthunk
  gdmShallowShow = error "gdmShallowShow not defined on the <<data meta type>>"

--- a/Debug/Hoed/Observe.lhs
+++ b/Debug/Hoed/Observe.lhs
@@ -1,5 +1,6 @@
 \begin{code}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE DefaultSignatures #-}

--- a/Debug/Hoed/Observe.lhs
+++ b/Debug/Hoed/Observe.lhs
@@ -513,7 +513,7 @@ unsafeWithUniq fn
 \begin{code}
 generateContext :: (a->Parent->a) -> String -> a -> (a,Int)
 generateContext f {- tti -} label orig = unsafeWithUniq $ \node ->
-     do sendEvent node (Parent 0 0) (Observe label node)
+     do sendEvent node (Parent 0 0) (Observe label)
         return (observer_ f orig (Parent
                       { parentUID      = node
                       , parentPosition = 0
@@ -573,7 +573,7 @@ data Event = Event
         deriving (Eq,Generic)
 
 data Change
-        = Observe       !String        !Int
+        = Observe       !String
         | Cons    !Int  !String
         | Enter
         | Fun

--- a/Debug/Hoed/Observe.lhs
+++ b/Debug/Hoed/Observe.lhs
@@ -89,32 +89,20 @@ module Debug.Hoed.Observe
 \begin{code}
 import Prelude hiding (Right)
 import qualified Prelude
-import System.IO
-import Data.Maybe
 import Control.Monad
 import Data.Array as Array
-import Data.List
-import Data.Char
 import Debug.Hoed.Fields
-import System.Environment
 
 import GHC.Generics
 
 import Data.IORef
 import System.IO.Unsafe
 
-import Control.Concurrent(takeMVar,putMVar,MVar,newMVar)
-import qualified Control.Concurrent as Concurrent
-\end{code}
-
-For the TracedMonad instance of IO:
-\begin{code}
-import GHC.Base hiding (mapM, Type)
 \end{code}
 
 \begin{code}
 import qualified Control.Exception as Exception
-import Control.Exception (Exception, throw, ErrorCall(..), SomeException(..))
+import Control.Exception (throw, SomeException(..))
 {-
  ( catch
                 , Exception(..)

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -165,8 +165,8 @@ eventsToCDS pairs = force $ getChild 0 0
      getNode'' ::  Int -> Event -> Change -> CDS
      getNode'' node _e change =
        case change of
-        (Observe str i) -> let chd = getChild node 0
-                               in CDSNamed str (getId chd i) chd
+        Observe str         -> let chd = getChild node 0
+                               in CDSNamed str (getId chd node) chd
         Enter               -> CDSEntered node
         Fun                 -> CDSFun node (getChild node 0) (getChild node 1)
         (Cons portc cons)

--- a/Debug/Hoed/Serialize.hs
+++ b/Debug/Hoed/Serialize.hs
@@ -17,7 +17,6 @@ import qualified Prelude as Prelude
 import Debug.Hoed.CompTree
 import Debug.Hoed.Render(CompStmt(..), StmtDetails(..))
 import Data.Serialize
-import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import GHC.Generics
 import Data.Graph.Libgraph(Judgement(..),AssistedMessage(..),mapGraph,Graph(..),Arc(..))
@@ -25,6 +24,7 @@ import Data.Graph.Libgraph(Judgement(..),AssistedMessage(..),mapGraph,Graph(..),
 --------------------------------------------------------------------------------
 -- Derive Serialize instances
 
+-- Orphan instances
 instance (Serialize a, Serialize b) => Serialize (Graph a b)
 instance (Serialize a, Serialize b) => Serialize (Arc a b)
 instance Serialize Vertex

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -47,6 +47,7 @@ library
                        , regex-tdfa
                        , directory
                        , cereal, bytestring
+                       , semigroups
                        , strict
                        , template-haskell
                        , terminal-size

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -33,6 +33,7 @@ library
                        , Debug.Hoed.EventForest
                        , Debug.Hoed.ReadLine
                        , Debug.Hoed.Console
+                       , Debug.Hoed.Fields
                        , Debug.Hoed.Prop
                        , Debug.Hoed.Serialize
                        , Text.PrettyPrint.FPretty

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -40,6 +40,7 @@ library
   build-depends:       base >= 4 && <5
                        , array, containers
                        , clock
+                       , deepseq
                        , process
                        , filepath
                        , libgraph == 1.14
@@ -47,6 +48,8 @@ library
                        , mtl
                        , directory
                        , cereal, bytestring
+                       , open-browser
+                       , strict
                        , template-haskell
                        , terminal-size
                        , time

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -39,6 +39,7 @@ library
                        , Paths_Hoed
   build-depends:       base >= 4 && <5
                        , array, containers
+                       , clock
                        , process
                        , filepath
                        , libgraph == 1.14

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -51,4 +51,5 @@ library
                        , terminal-size
                        , time
                        , uniplate
+                       , vector
   default-language:    Haskell2010

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -43,17 +43,13 @@ library
                        , clock
                        , deepseq
                        , process
-                       , filepath
                        , libgraph == 1.14
                        , regex-tdfa
-                       , mtl
                        , directory
                        , cereal, bytestring
-                       , open-browser
                        , strict
                        , template-haskell
                        , terminal-size
-                       , time
                        , uniplate
                        , vector
   default-language:    Haskell2010

--- a/examples/quicksort.hs
+++ b/examples/quicksort.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE ViewPatterns #-}
+import Debug.Hoed
+import qualified Data.List
+
+quicksort :: Observable a => (a -> a -> Bool) -> [a] -> [a]
+quicksort = observe "quicksort" quicksort'
+quicksort' op [] = []
+quicksort' op (x:xs) = id_quicksort $ quicksort op lt ++ [x] ++ quicksort op gt
+    where (observe "lt" . id_lt -> lt, observe "gt" -> gt) = partition (`op` x) xs
+
+partition :: Observable a => (a -> Bool) -> [a] -> ([a],[a])
+partition = observe "partition" partition'
+{-# INLINE partition #-}
+partition' p xs = foldr (select p) ([],[]) (id_partition xs)
+
+select :: Observable a => (a -> Bool) -> a -> ([a], [a]) -> ([a], [a])
+-- select = observe "select" select'
+select p x ~(ts,fs) | p x       = (x:ts,fs)
+                     | otherwise = (ts, x:fs)
+
+main = printO $ quicksort (<=) "haskell"
+
+id_quicksort, id_partition,id_lt :: Observable a => a -> a
+id_quicksort = observe "id_quicksort" $ \x -> x
+id_partition = observe "id_partition" $ \x -> x
+id_lt = observe "id_lt" $ \x -> x

--- a/tests/Generic/t64.hs
+++ b/tests/Generic/t64.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# OPTIONS -fdefer-type-errors #-}
+import Debug.Hoed
+
+-- Should build
+data T64 = T64 { t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,t16,t17,t18,t19,t20,t21,t22,t23,t24,t25,t26,t27,t28,t29,t30
+               , t31,t32,t33,t34,t35,t36,t37,t38,t39,t40,t41,t42,t43,t44,t45,t46,t47,t48,t49,t50,t51,t52,t53,t54,t55,t56,t57,t58
+               , t59,t60,t61,t62,t63,t64 :: ()}
+           deriving Generic
+
+instance Observable T64
+
+data F65 = F65 { f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13,f14,f15,f16,f17,f18,f19,f20,f21,f22,f23,f24,f25,f26,f27,f28,f29,f30
+               , f31,f32,f33,f34,f35,f36,f37,f38,f39,f40,f41,f42,f43,f44,f45,f46,f47,f48,f49,f50,f51,f52,f53,f54,f55,f56,f57,f58
+               , f59,f60,f61,f62,f63,f64,f65 :: ()}
+           deriving (Generic, Show)
+
+-- Should type erro with "Hoed handles constructors with 64 fields or less"
+instance Observable F65


### PR DESCRIPTION
The construction of the computation graph is now between 4 and 5 times faster in my benchmarks. The benchmark asks Hoed to calculate the computation graph for the trace corresponding to the evaluation below and measures the time needed:
```
=== Statistics ===

2908632 events
366 computation statements
366 nodes + 1 virtual root node in the computation tree
378 edges in computation tree
computation tree has a branch factor of 2.885496183206107 (i.e the average number of children of non-leaf nodes)
```

Before: 17.15 seconds
After: 3.43 seconds

The optimisations revolve mostly around data structures and strictness, including: 
1. The use of arrays instead of `IntMap`s in the `traceInfo` loop.
2. The use of an array of bitmaps instead of an `IntMap` for the `ConsMap` data structure that collects Cons spans.
3. The use a zipper-like data structure to store the stack of ongoing computations.
4. The manual inlining of all the simplify CDS passes into `eventsToCDS`.

For optimisation 2 above the bitmap size is 64 bit (in x64 arch), which implies that Hoed can only analyse constructors with up to 64 fields. It would be possible to lift this restriction with a bigger bitmap size, at the cost of some space. To ensure soundness, I've included a type level check for the number of fields in the constructors of a datatype.

The changes are quite substantial, so let me know if there is anything I can do to further facilitate the review.
  