### PR TITLE
Fixes to pauseSpan

### DIFF
--- a/Debug/Hoed/CompTree.hs
+++ b/Debug/Hoed/CompTree.hs
@@ -51,6 +51,7 @@ import           Debug.Hoed.Render
 
 import           Data.Bits
 import           Data.Graph.Libgraph
+import qualified Data.Set               as Set
 import           Data.IntMap.Strict     (IntMap)
 import qualified Data.IntMap.Strict     as IntMap
 import           Data.IntSet            (IntSet)
@@ -117,7 +118,9 @@ isRootVertex RootVertex = True
 isRootVertex _          = False
 
 leafs :: CompTree -> [Vertex]
-leafs g = filter (null . succs g) (vertices g)
+leafs g = filter (not . (`Set.member` nonLeafs)) (vertices g)
+  where
+    nonLeafs = Set.fromList [s | Arc s t _ <- arcs g]
 
 -- | Approximates the complexity of a computation tree by summing the length
 -- of the unjudged computation statements (i.e not Right or Wrong) in the tree.

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -117,8 +117,8 @@ renderNamedTop name _ other = error $ show other
 -- local nub for sorted lists
 nubSorted :: Eq a => [a] -> [a]
 nubSorted []        = []
-nubSorted (a:a':as) | a == a' = nub (a' : as)
-nubSorted (a:as)    = a : nub as
+nubSorted (a:a':as) | a == a' = nubSorted (a' : as)
+nubSorted (a:as)    = a : nubSorted as
 
 -- %************************************************************************
 -- %*                                                                   *

--- a/Debug/Hoed/Span.hs
+++ b/Debug/Hoed/Span.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE MultiWayIf            #-}
+{-# LANGUAGE OverloadedLists       #-}
+{-# LANGUAGE ViewPatterns #-}
+module Debug.Hoed.Span
+  ( Span(..)
+  , getSpanUID
+  , SpanZipper
+  , startSpan
+  , stopSpan
+  , pauseSpan
+  , resumeSpan
+  , runSpanTests
+  ) where
+
+import           Control.Exception as E
+import           Debug.Hoed.Observe
+
+import           Data.List              (foldl', unfoldr)
+import           Data.Maybe
+import           GHC.Exts               (IsList (..))
+
+import Debug.Trace
+import Test.QuickCheck
+import Test.QuickCheck.All
+
+data Span = Computing !UID | Paused !UID deriving (Eq, Ord)
+
+instance Show Span where
+  show (Computing i) = show i
+  show (Paused i)    = "(" ++ show i ++ ")"
+
+getSpanUID :: Span -> UID
+getSpanUID (Computing j) = j
+getSpanUID (Paused j)    = j
+
+data SpanList = SpanCons !UID !SpanList | SpanNil
+  deriving Eq
+
+instance IsList SpanList where
+  type Item SpanList = Span
+  toList = unfoldr f where
+    f SpanNil = Nothing
+    f (SpanCons uid rest)
+      | uid > 0   = Just (Computing uid, rest)
+      | otherwise = Just (Paused (negate uid), rest)
+  fromList = foldr f SpanNil where
+    f (Paused uid) = SpanCons (negate uid)
+    f (Computing uid) = SpanCons uid
+
+instance Show SpanList where show = show . toList
+
+data SpanZipper
+  = SZ { left :: !SpanList
+      ,  cursorUID :: !UID
+      ,  right :: !SpanList}
+  | SZNil
+  deriving Eq
+
+instance IsList SpanZipper where
+  type Item SpanZipper = Span
+  toList SZNil = []
+  toList (SZ l uid r) = reverse(toList l) ++ toList (SpanCons uid r)
+
+  fromList [] = SZNil
+  fromList (Paused x : xx) = SZ [] (negate x) (fromList xx)
+  fromList (Computing x : xx) = SZ [] x (fromList xx)
+
+newtype Verbatim = Verbatim String
+instance Show Verbatim where show (Verbatim s) = s
+
+instance Show SpanZipper where
+  show SZNil = "[]"
+  show SZ {..} =
+    show $
+    map (Verbatim . show) (toList left) ++
+    Verbatim ('\ESC':"[4m" ++ show cursorUID ++ '\ESC':"[24m") :
+    map (Verbatim . show) (toList right)
+
+startSpan :: UID -> SpanZipper -> SpanZipper
+startSpan uid SZNil = SZ [] uid []
+startSpan uid SZ{..}  = SZ [] uid (left <> SpanCons cursorUID right)
+  where
+    SpanNil <> x = x
+    x <> SpanNil = x
+    SpanCons uid rest <> x = rest <> SpanCons uid x
+
+moveLeft, moveRight :: SpanZipper -> Maybe SpanZipper
+moveLeft SZNil = Nothing
+moveLeft SZ{left = SpanNil} = Nothing
+moveLeft SZ{left = SpanCons uid l, ..} = Just $ SZ l uid (SpanCons cursorUID right)
+
+moveRight SZNil = Nothing
+moveRight SZ{right = SpanNil} = Nothing
+moveRight SZ{right = SpanCons uid r, ..} = Just $ SZ (SpanCons cursorUID left) uid r
+
+-- pauseSpan always moves to the right, except when at the bottom of the stack in which case it goes left
+pauseSpan :: UID -> SpanZipper -> SpanZipper
+pauseSpan uid sz
+  | SZNil <- sz = sz
+  | x == uid = sz {cursorUID = negate uid}
+  | SpanNil <- right sz
+  , SpanCons a aa <- fromListWithReverse $ toList (SpanCons x (left sz)) -- this should fuse!
+   = go (SZ [] a aa)
+  | Just sz' <- moveRight sz {cursorUID = negative x} = pauseSpan uid sz'
+  | otherwise = assert notLeft sz
+  where
+    x = cursorUID sz
+    negative x =
+      if x < 0
+        then x
+        else negate x
+    fromListWithReverse = foldl f SpanNil
+      where
+        f rest (Paused uid) = SpanCons (negate uid) rest
+        f rest (Computing uid) = SpanCons uid rest
+    notLeft =
+      (Computing uid `notElem` toList (left sz)) ||
+      error (unwords ["pauseSpan", show uid, show sz])
+    go sz
+      | cursorUID sz == uid = sz {cursorUID = negate uid}
+      | Just sz' <- moveRight sz {cursorUID = negative (cursorUID sz)} = go sz'
+      | otherwise = sz
+
+-- resumeSpan moves to the left, except when at the Top of the stack in which case it goes right
+resumeSpan :: UID -> SpanZipper -> SpanZipper
+resumeSpan (negate -> uid) sz
+  | SZNil <- sz = sz
+  | cursorUID sz == uid = sz{cursorUID = negate uid}
+  | SpanNil <- left sz, Just sz' <- moveRight sz = go moveRight sz'
+  | Just sz' <- moveLeft sz = go moveLeft sz'
+  | otherwise = assert (Computing uid `notElem` toList (right sz)) sz
+  where
+    go move sz
+      | cursorUID sz == uid = sz{cursorUID = negate uid}
+      | Just sz' <- move sz = go move sz'
+      | otherwise = sz
+
+-- stopSpan moves left
+stopSpan :: UID -> SpanZipper -> SpanZipper
+stopSpan uid sz@SZ{..}
+  | uid == abs cursorUID = if
+      | Just sz' <- moveRight sz -> sz'{left = left}
+      | Just sz' <- moveLeft  sz -> sz'{right = right}
+      | otherwise -> SZNil
+  | Just sz' <- moveLeft sz = stopSpan uid sz'
+stopSpan uid sz = error $ unwords ["stopSpan", show uid, show sz]
+
+
+---------------------------------------------------------
+-- Properties
+instance Arbitrary Span where
+  arbitrary = do
+    computing <- arbitrary
+    uid <- arbitrary
+    return $ if computing then Computing (abs uid + 1) else Paused (abs uid + 1)
+
+instance Arbitrary SpanList where
+  arbitrary = fromList <$> arbitrary
+  shrink [] = []
+  shrink (SpanCons a rest) = [SpanNil, rest] ++ [SpanCons a l' | l' <- shrink rest]
+
+instance Arbitrary SpanZipper where
+  arbitrary = oneof [pure SZNil, SZ <$> arbitrary <*> arbitrary <*> arbitrary]
+  shrink SZNil = []
+  shrink (SZ l x r) = [SZ l' x r' | (l',r') <- shrink (l,r)]
+
+prop_SpanList1 :: [Span] -> Bool
+prop_SpanList1 xx = toList(fromList xx :: SpanList) == xx
+prop_SpanList2 :: SpanList -> Bool
+prop_SpanList2 xx = fromList(toList xx) == xx
+
+prop_SpanZipper1 :: [Span] -> Bool
+prop_SpanZipper1 xx = toList(fromList xx :: SpanZipper) == xx
+prop_SpanZipper2 :: SpanZipper -> Bool
+prop_SpanZipper2 xx = toList(fromList @SpanZipper (toList xx)) == toList xx
+
+prop_LR, prop_RL :: SpanZipper -> Property
+prop_LR x = isJust(moveRight x) ==> (moveLeft  =<< moveRight x) == Just x
+prop_RL x = isJust(moveLeft  x) ==> (moveRight =<< moveLeft  x) == Just x
+
+return []
+runSpanTests = $quickCheckAll

--- a/Debug/Hoed/Span.hs
+++ b/Debug/Hoed/Span.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -188,7 +187,7 @@ prop_SpanList2 xx = fromList(toList xx) == xx
 prop_SpanZipper1 :: [Span] -> Bool
 prop_SpanZipper1 xx = toList(fromList xx :: SpanZipper) == xx
 prop_SpanZipper2 :: SpanZipper -> Bool
-prop_SpanZipper2 xx = toList(fromList @SpanZipper (toList xx)) == toList xx
+prop_SpanZipper2 xx = toList(fromList (toList xx) :: SpanZipper) == toList xx
 
 prop_LR, prop_RL :: SpanZipper -> Property
 prop_LR x = isJust(moveRight x) ==> (moveLeft  =<< moveRight x) == Just x

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -35,6 +35,7 @@ library
                        , Debug.Hoed.Fields
                        , Debug.Hoed.Prop
                        , Debug.Hoed.Serialize
+                       , Debug.Hoed.Span
                        , Text.PrettyPrint.FPretty
                        , Paths_Hoed
   build-depends:       base >= 4 && <5
@@ -46,6 +47,7 @@ library
                        , regex-tdfa
                        , directory
                        , cereal, bytestring
+                       , QuickCheck
                        , semigroups
                        , strict
                        , template-haskell

--- a/examples/Queens__with_properties/Queens.hs
+++ b/examples/Queens__with_properties/Queens.hs
@@ -13,7 +13,7 @@ import Types
 
 test1 :: IO ()
 test1 = do
-  (HoedAnalysis _ ct) <- runO' defaultHoedOptions (print $ queens 8)
+  (HoedAnalysis _ ct) <- runO' defaultHoedOptions (print $ queens 7)
   -- TODO compare ct with a stored version to do regression testing
   return ()
 


### PR DESCRIPTION
This PR fixes the infinite loop in pauseSpan, together with a correctness bug that showed up after adding QuickCheck properties. And a few simple performance fixes.