### PR TITLE
Fix build with GHC 8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,12 @@ matrix:
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.2.2"
+    addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.4.1 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.4.1"
+    addons: {apt: {packages: [cabal-install-2.0,ghc-8.4.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.

--- a/Debug/Hoed.hs
+++ b/Debug/Hoed.hs
@@ -328,11 +328,13 @@ data HoedAnalysis = HoedAnalysis
   , hoedCompTree    :: CompTree
   }
 
+-- | Configuration options for running Hoed
 data HoedOptions = HoedOptions
   { verbose     :: Verbosity
   , prettyWidth :: Int
   }
 
+-- | The default is to run silent and pretty print with a width of 110 characters
 defaultHoedOptions :: HoedOptions
 defaultHoedOptions = HoedOptions Silent 110
 

--- a/Debug/Hoed/Render.hs
+++ b/Debug/Hoed/Render.hs
@@ -34,7 +34,6 @@ import           Data.Char                (isAlpha)
 import           Data.Coerce
 import           Data.Hashable
 import           Data.List                (nub, sort, unfoldr)
-import qualified Data.HashTable.ST.Cuckoo as H
 import           Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
 import           Data.Map.Strict (Map)

--- a/Hoed.cabal
+++ b/Hoed.cabal
@@ -52,7 +52,6 @@ library
                        , bytestring
                        , cereal, cereal-text, cereal-vector
                        , hashable >= 1.2.5
-                       , hashtables
                        , QuickCheck
                        , open-browser
                        , primitive
@@ -63,6 +62,7 @@ library
                        , text
                        , transformers
                        , uniplate
+                       , unordered-containers
                        , vector
                        , vector-th-unbox
   default-language:    Haskell2010

--- a/Text/PrettyPrint/FPretty.hs
+++ b/Text/PrettyPrint/FPretty.hs
@@ -118,6 +118,7 @@ import Prelude hiding ((<$>))
 
 import Data.Hashable
 import Data.Maybe (fromJust)
+import Data.Semigroup
 import Data.Sequence as Dequeue (Seq, (<|), viewl, viewr, ViewL(..), ViewR(..))
 import qualified Data.Sequence as Dequeue (empty)
   -- Originally used Banker's dequeue from Okasaki's book 
@@ -127,7 +128,7 @@ import qualified Data.Sequence as Dequeue (empty)
 import Data.String
 import GHC.Generics
 
-infixr 6 <>,<+>
+infixr 6 <+>
 infixr 5 <$>,<$$>,</>,<//>
 
 ----------------------
@@ -218,10 +219,6 @@ line :: Doc
 -- | Either nothing ('empty') or a new line.
 linebreak :: Doc
 
--- | Horizontal composition of two documents. 
--- Is associative with identity 'empty'.
-(<>) :: Doc -> Doc -> Doc
-
 -- | Mark document as group, that is, layout as a single line if possible.
 -- Within a group for all basic documents with several layouts the same layout
 -- is chosen, that is, they are all horizontal or all new lines.
@@ -257,11 +254,19 @@ instance Hashable Doc
 instance IsString Doc where
   fromString = text
 
+instance Semigroup Doc where
+  -- | Horizontal composition of two documents.
+  (<>) = (:<>)
+
+instance Monoid Doc where
+  mempty = empty
+#if !(MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+#endif
 empty = Nil
 text t = Text (length t) t
 line = Line 1 " "
 linebreak = Line 0 ""
-(<>) = (:<>)
 group = Group
 nest = Nest
 align = Align 0


### PR DESCRIPTION
The problems were:
- The hashtable package not yet updated to GHC 8.4. Fixed by replacing it with unordered-containers. I don't expect any major perf changes due to this change

- The (<>) operator in FPretty clashing with (Data.Monoid.<>) which is now reexported from the Prelude. Fixed by making a Monoid instance for Doc so that the operator can be reused.

Please merge and make a release asap. Thanks !